### PR TITLE
18 spotify links refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BootMe
-**Version 0.11.0**
+**Version 0.11.1**
 
 BootMe is a personal productivity application that automates the setup of your work environment, allowing you to focus on what really matters. It handles opening up necessary apps, setting up your favorite music on Spotify, cleaning up your desktop, and more, all with a single command.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BootMe
-**Version 0.11.1**
+**Version 0.12**
 
 BootMe is a personal productivity application that automates the setup of your work environment, allowing you to focus on what really matters. It handles opening up necessary apps, setting up your favorite music on Spotify, cleaning up your desktop, and more, all with a single command.
 

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ settings_button.grid(row=0, column=1, sticky="ne")
 
 config_manager = ConfigManager(config_file_path)
 
-main_ui = MainUIManager(root, config_manager, settings_button)
+main_ui = MainUIManager(root, config_manager, open_settings)
 
 root.grid_columnconfigure(0, weight=1)
 root.grid_columnconfigure(1, weight=1)

--- a/main.py
+++ b/main.py
@@ -9,6 +9,9 @@ def open_settings():
   settings_window = tk.Toplevel(root)
   settings_manager = SettingsUIManager(settings_window, config_manager)
 
+  root.wait_window(settings_window)
+  main_ui.refresh_buttons()
+
 script_dir = os.path.dirname(os.path.abspath(__file__))
 config_file_path = os.path.join(script_dir, "config.json")
 
@@ -20,12 +23,12 @@ root.configure(bg="#a9927d")
 title_label = tk.Label(root, text="BootMe", font=("Helvetica", 24), bg="#a9927d", fg="#5c5241")
 title_label.grid(row=0, column=0, columnspan=2, sticky="nsew")
 
-edit_button = tk.Button(root, text="Settings", command=open_settings)
-edit_button.grid(row=0, column=1, sticky="ne")
+settings_button = tk.Button(root, text="Settings", command=open_settings)
+settings_button.grid(row=0, column=1, sticky="ne")
 
 config_manager = ConfigManager(config_file_path)
 
-main_ui = MainUIManager(root, config_manager)
+main_ui = MainUIManager(root, config_manager, settings_button)
 
 root.grid_columnconfigure(0, weight=1)
 root.grid_columnconfigure(1, weight=1)

--- a/scripts/config_manager.py
+++ b/scripts/config_manager.py
@@ -21,8 +21,8 @@ class ConfigManager:
           ],
           "apps": [],
           "spotify_url": "",
-          "spotify_type": "album",
-          "spotify_id": "18NOKLkZETa4sWwLMIm0UZ"
+          "spotify_type": "",
+          "spotify_id": ""
         },
         {
           "name": "Recruiting Environment",
@@ -31,35 +31,38 @@ class ConfigManager:
             "https://www.linkedin.com/jobs/",
             "https://leetcode.com/explore/interview/card/top-interview-questions-easy/92/array/"
           ],
-          "apps":[],
+          "apps": [],
           "spotify_url": "",
-          "spotify_type": "album",
-          "spotify_id": "18NOKLkZETa4sWwLMIm0UZ"
+          "spotify_type": "",
+          "spotify_id": ""
         },
         {
           "name": "Extra Environment 1",
           "links": [
             "https://www.google.com/"
           ],
-          "apps":[],
+          "apps": [],
           "spotify_url": "",
-          "spotify_type": "none",
-          "spotify_id": "none"
+          "spotify_type": "",
+          "spotify_id": ""
         },
         {
           "name": "Extra Environment 2",
           "links": [
             "https://www.google.com/"
           ],
-          "apps":[],
+          "apps": [],
           "spotify_url": "",
-          "spotify_type": "playlist",
-          "spotify_id": "spotify:playlist:5sXRm52jnGFLluxfgeZ1Ng"
+          "spotify_type": "",
+          "spotify_id": ""
         }
-      ], 
+      ],
       "workflows": {
         "kill_all_apps": [],
-        "clean_desktop_ignore_list": ["TRASH_ME", "ORGANIZE_ME"]
+        "clean_desktop_ignore_list": [
+          "TRASH_ME",
+          "ORGANIZE_ME"
+        ]
       }
     }
     self.write_config(default_config)

--- a/scripts/config_manager.py
+++ b/scripts/config_manager.py
@@ -20,6 +20,7 @@ class ConfigManager:
             "https://google.com/"
           ],
           "apps": [],
+          "spotify_url": "",
           "spotify_type": "album",
           "spotify_id": "18NOKLkZETa4sWwLMIm0UZ"
         },
@@ -31,6 +32,7 @@ class ConfigManager:
             "https://leetcode.com/explore/interview/card/top-interview-questions-easy/92/array/"
           ],
           "apps":[],
+          "spotify_url": "",
           "spotify_type": "album",
           "spotify_id": "18NOKLkZETa4sWwLMIm0UZ"
         },
@@ -40,6 +42,7 @@ class ConfigManager:
             "https://www.google.com/"
           ],
           "apps":[],
+          "spotify_url": "",
           "spotify_type": "none",
           "spotify_id": "none"
         },
@@ -49,6 +52,7 @@ class ConfigManager:
             "https://www.google.com/"
           ],
           "apps":[],
+          "spotify_url": "",
           "spotify_type": "playlist",
           "spotify_id": "spotify:playlist:5sXRm52jnGFLluxfgeZ1Ng"
         }

--- a/scripts/main_ui_manager.py
+++ b/scripts/main_ui_manager.py
@@ -2,9 +2,10 @@ import tkinter as tk
 from scripts.trigger_actions import (trigger_env, on_click_kill_all, on_click_clean_desktop)
 
 class MainUIManager:
-  def __init__(self, master, config_manager):
-    self.master = master
+  def __init__(self, root_frame, config_manager, settings_button):
+    self.root_frame = root_frame
     self.config_manager = config_manager
+    self.settings_button = settings_button
     self.create_buttons()
 
   def create_buttons(self):
@@ -13,5 +14,12 @@ class MainUIManager:
     button_commands = [lambda i=i: trigger_env(i) for i in range(len(data["environments"]))] + [on_click_kill_all, on_click_clean_desktop]
 
     for i in range(6):
-      button = tk.Button(self.master, text=button_text[i], command=button_commands[i], width=20, height=2, bg="#cbb294", fg="#5c5241")
+      button = tk.Button(self.root_frame, text=button_text[i], command=button_commands[i], width=20, height=2, bg="#cbb294", fg="#5c5241")
       button.grid(row=(i//2)+1, column=i%2, padx=20, pady=10, sticky="nsew", ipadx=10, ipady=10)
+
+  def refresh_buttons(self):
+    for widget in self.root_frame.winfo_children():
+      if widget.winfo_name() != self.settings_button:
+        widget.destroy()
+
+    self.create_buttons()

--- a/scripts/main_ui_manager.py
+++ b/scripts/main_ui_manager.py
@@ -2,11 +2,18 @@ import tkinter as tk
 from scripts.trigger_actions import (trigger_env, on_click_kill_all, on_click_clean_desktop)
 
 class MainUIManager:
-  def __init__(self, root_frame, config_manager, settings_button):
+  def __init__(self, root_frame, config_manager, open_settings_cb):
     self.root_frame = root_frame
     self.config_manager = config_manager
-    self.settings_button = settings_button
+    self.create_title_and_settings_button(open_settings_cb)
     self.create_buttons()
+
+  def create_title_and_settings_button(self, open_settings_cb):
+    self.title_label = tk.Label(self.root_frame, text="BootMe", font=("Helvetica", 24), bg="#a9927d", fg="#5c5241")
+    self.title_label.grid(row=0, column=0, columnspan=2, sticky="nsew")
+
+    self.settings_button = tk.Button(self.root_frame, text="Settings", command=open_settings_cb)
+    self.settings_button.grid(row=0, column=1, sticky="ne")
 
   def create_buttons(self):
     data = self.config_manager.read_config()
@@ -19,7 +26,7 @@ class MainUIManager:
 
   def refresh_buttons(self):
     for widget in self.root_frame.winfo_children():
-      if widget.winfo_name() != self.settings_button:
+      if widget not in (self.title_label, self.settings_button):
         widget.destroy()
 
     self.create_buttons()

--- a/scripts/settings_ui_manager.py
+++ b/scripts/settings_ui_manager.py
@@ -4,8 +4,6 @@ from scripts.edit_dialog import EditDialog
 from scripts.config_manager import ConfigManager
 from scripts.spoticry import Spoticry
 
-import pdb
-
 class SettingsUIManager:
   def __init__(self, root, config_manager):
     self.root = root
@@ -217,11 +215,8 @@ class SettingsUIManager:
 
 
   def save_config(self):
-    # pdb.set_trace()
-
     selection = self.selection_var.get()
 
-    # Bug change selection to read the the list of options for the name 
     envs = self.current_config["environments"]
     names = [env["name"] for env in envs]
     names.append("Kill All")

--- a/scripts/settings_ui_manager.py
+++ b/scripts/settings_ui_manager.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import messagebox, ttk, simpledialog
 from scripts.edit_dialog import EditDialog
 from scripts.config_manager import ConfigManager
+from scripts.spoticry import Spoticry
 
 class SettingsUIManager:
   def __init__(self, root, config_manager):
@@ -96,7 +97,7 @@ class SettingsUIManager:
 
     if environment["spotify_type"] != "none":
       self.spotify_play_var.set("Yes")
-      self.spotify_link_entry.insert(0, environment["spotify_id"])
+      self.spotify_link_entry.insert(0, environment["spotify_url"])
     else:
       self.spotify_play_var.set("No")
 
@@ -223,10 +224,29 @@ class SettingsUIManager:
       self.current_config["environments"][index]["links"] = links
       self.current_config["environments"][index]["apps"] = apps
       
+      '''
+      import Spoticry
+      Change if else:
+      spoticry = Spoticry()
       if spotify_play:
-        self.current_config["environments"][index]["spotify_type"] = spotify_link.split(":")[1]
-        self.current_config["environments"][index]["spotify_id"] = spotify_link.split(":")[2]
+        self.current_config["environments"][index]["spotify_url"] = spotify_link
+        play_data = spoticry.parse_link(spotify_link)
+        self.current_config["environments"][index]["spotify_type"] = play_data[0]
+        self.current_config["environments"][index]["spotify_id"] = play_data[1]
       else:
+        self.current_config["environments"][index]["spotify_url"] = "none"
+        self.current_config["environments"][index]["spotify_type"] = "none"
+        self.current_config["environments"][index]["spotify_id"] = "none"
+      '''
+
+      spoticry = Spoticry()
+      if spotify_play:
+        self.current_config["environments"][index]["spotify_url"] = spotify_link
+        play_data = spoticry.parse_link(spotify_link)
+        self.current_config["environments"][index]["spotify_type"] = play_data[0]
+        self.current_config["environments"][index]["spotify_id"] = play_data[1]
+      else:
+        self.current_config["environments"][index]["spotify_url"] = "none"
         self.current_config["environments"][index]["spotify_type"] = "none"
         self.current_config["environments"][index]["spotify_id"] = "none"
     
@@ -243,5 +263,3 @@ class SettingsUIManager:
     # Save the updated config using config_manager
     self.config_manager.write_config(self.current_config)
     tk.messagebox.showinfo("Saved", "Configuration saved successfully!")
-
-

--- a/scripts/settings_ui_manager.py
+++ b/scripts/settings_ui_manager.py
@@ -21,7 +21,6 @@ class SettingsUIManager:
     options = [env["name"] for env in envs]
     options.append("Kill All")
     options.append("Clean Desktop")
-    # options = ["Button " + str(i+1) for i in range(6)]
     self.selection_dropdown = ttk.Combobox(self.root, textvariable=self.selection_var, values=options)
     self.selection_dropdown.bind("<<ComboboxSelected>>", self.load_fields_for_selection)
     self.selection_dropdown.pack(pady=10)
@@ -90,24 +89,11 @@ class SettingsUIManager:
     for app in environment["apps"]:
       self.apps_listbox.insert(tk.END, app)
 
-    # Spotify fields
-    spotify_play_label = tk.Label(self.fields_frame, text="Play Spotify:")
-    spotify_play_label.grid(row=5, column=0, sticky="e")
-    self.spotify_play_var = tk.StringVar()
-    self.spotify_play_var.set("No")
-    spotify_play_dropdown = ttk.Combobox(self.fields_frame, textvariable=self.spotify_play_var, values=["Yes", "No"])
-    spotify_play_dropdown.grid(row=5, column=1, columnspan=2)
-
     spotify_link_label = tk.Label(self.fields_frame, text="Spotify Link:")
     spotify_link_label.grid(row=6, column=0, sticky="e")
     self.spotify_link_entry = tk.Entry(self.fields_frame)
     self.spotify_link_entry.grid(row=6, column=1, columnspan=2)
-
-    if environment["spotify_type"] != "none":
-      self.spotify_play_var.set("Yes")
-      self.spotify_link_entry.insert(0, environment["spotify_url"])
-    else:
-      self.spotify_play_var.set("No")
+    self.spotify_link_entry.insert(0, environment["spotify_url"])
 
 
   def add_link(self):
@@ -229,7 +215,7 @@ class SettingsUIManager:
       name = self.name_entry.get()
       links = [self.links_listbox.get(i) for i in range(self.links_listbox.size())]
       apps = [self.apps_listbox.get(i) for i in range(self.apps_listbox.size())]
-      spotify_play = True if self.spotify_play_var.get() == "Yes" else False
+      spotify_play = bool(self.spotify_link_entry.get().strip())
       spotify_link = self.spotify_link_entry.get() if spotify_play else None
       
       # Update the current_config dictionary

--- a/scripts/settings_ui_manager.py
+++ b/scripts/settings_ui_manager.py
@@ -4,6 +4,8 @@ from scripts.edit_dialog import EditDialog
 from scripts.config_manager import ConfigManager
 from scripts.spoticry import Spoticry
 
+import pdb
+
 class SettingsUIManager:
   def __init__(self, root, config_manager):
     self.root = root
@@ -16,7 +18,12 @@ class SettingsUIManager:
 
   def build_ui(self):
     self.selection_var = tk.StringVar()
-    options = ["Button " + str(i+1) for i in range(6)]
+
+    envs = self.current_config["environments"]
+    options = [env["name"] for env in envs]
+    options.append("Kill All")
+    options.append("Clean Desktop")
+    # options = ["Button " + str(i+1) for i in range(6)]
     self.selection_dropdown = ttk.Combobox(self.root, textvariable=self.selection_var, values=options)
     self.selection_dropdown.bind("<<ComboboxSelected>>", self.load_fields_for_selection)
     self.selection_dropdown.pack(pady=10)
@@ -34,13 +41,16 @@ class SettingsUIManager:
 
     selection = self.selection_var.get()
 
-    if selection in ["Button 1", "Button 2", "Button 3", "Button 4"]:
-      # Compute the index based on the selection
-      index = int(selection.split(" ")[-1]) - 1
+    envs = self.current_config["environments"]
+    names = [env["name"] for env in envs]
+    names.append("Kill All")
+    names.append("Clean Desktop")
+    index = names.index(selection)
+    if index < 4:
       self.load_environment_fields(index)
-    elif selection == "Button 5":
+    elif index == 4:
       self.load_kill_all_fields()
-    elif selection == "Button 6":
+    else:
       self.load_clean_desktop_fields()
 
 
@@ -207,11 +217,19 @@ class SettingsUIManager:
 
 
   def save_config(self):
+    # pdb.set_trace()
+
     selection = self.selection_var.get()
-    
-    if selection in ["Button 1", "Button 2", "Button 3", "Button 4"]:
-      index = int(selection.split(" ")[-1]) - 1
-      
+
+    # Bug change selection to read the the list of options for the name 
+    envs = self.current_config["environments"]
+    names = [env["name"] for env in envs]
+    names.append("Kill All")
+    names.append("Clean Desktop")
+
+    index = names.index(selection)
+
+    if index < 4:
       # Read the data from UI fields
       name = self.name_entry.get()
       links = [self.links_listbox.get(i) for i in range(self.links_listbox.size())]
@@ -223,21 +241,6 @@ class SettingsUIManager:
       self.current_config["environments"][index]["name"] = name
       self.current_config["environments"][index]["links"] = links
       self.current_config["environments"][index]["apps"] = apps
-      
-      '''
-      import Spoticry
-      Change if else:
-      spoticry = Spoticry()
-      if spotify_play:
-        self.current_config["environments"][index]["spotify_url"] = spotify_link
-        play_data = spoticry.parse_link(spotify_link)
-        self.current_config["environments"][index]["spotify_type"] = play_data[0]
-        self.current_config["environments"][index]["spotify_id"] = play_data[1]
-      else:
-        self.current_config["environments"][index]["spotify_url"] = "none"
-        self.current_config["environments"][index]["spotify_type"] = "none"
-        self.current_config["environments"][index]["spotify_id"] = "none"
-      '''
 
       spoticry = Spoticry()
       if spotify_play:
@@ -250,12 +253,12 @@ class SettingsUIManager:
         self.current_config["environments"][index]["spotify_type"] = "none"
         self.current_config["environments"][index]["spotify_id"] = "none"
     
-    elif selection == "Button 5":
+    elif selection == "Kill All":
       # Read the data from UI fields
       apps_to_kill = [self.apps_kill_listbox.get(i) for i in range(self.apps_kill_listbox.size())]
       self.current_config["workflows"]["kill_all_apps"] = apps_to_kill
     
-    elif selection == "Button 6":
+    elif selection == "Clean Desktop":
       # Read the data from UI fields
       files_to_ignore = [self.files_ignore_listbox.get(i) for i in range(self.files_ignore_listbox.size())]
       self.current_config["workflows"]["clean_desktop_ignore_list"] = files_to_ignore

--- a/scripts/spoticry.py
+++ b/scripts/spoticry.py
@@ -34,24 +34,24 @@ class Spoticry:
       print("Valid token found in cache.")
 
     self.sp = spotipy.Spotify(auth=token_info["access_token"])
-    self.play_data = tuple()
-  
-  def start_spotify(self, spotify_link):
-    self.parse_link()
 
+
+  def start_spotify(self, spotify_link):
     if self.play_data[0] == "playlist":
       self.start_playlist(self.play_data(1))
     elif self.play_data[0] == "album":
       self.start_album(self.play_data(1))
 
+
   def parse_link(self, spotify_link):
     parsed_link = spotify_link.split("/")
     id = parsed_link[4].split("?")[0]
 
-    self.play_data = (parsed_link[3], id)
+    return (parsed_link[3], id)
 
 
-  def start_playlist(self, playlist_uri):
+  def start_playlist(self, playlist_id):
+    playlist_uri = f"spotify:playlist:{playlist_id}"
     self.sp.start_playback(context_uri=playlist_uri)
 
 


### PR DESCRIPTION
### Description

Please include a summary of the change and which issue is fixed or feature is introduced. Please also include relevant motivation and context.

Fixes #(issue_number)

### Summary

This pr allows the user to insert full spotify links rather than just the id. Also added the functionality to refresh the buttons after the settings window saved the configuration. I needed to refactor the default config and remove the option for `play spotify` dropdown because it was unnecessary. 

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (changes to documentation the user needs to know)

### Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- I removed config.json and ensured that the new default config is of the correct format. This tests the default creation.
- With a fresh config, I customized the buttons with a new name, link, app, and spotify link. I then saved the config and closed the settings window. I clicked the newly configured button which launched the new changes. 

### Additional Context (optional)

I changed the versioning from X.X.X to X.X 
I felt that it wasn't necessary for 3 degrees of versioning, but this can change. 
