### PR TITLE
23 featsettings implement save default app location in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BootMe
-**Version 0.14**
+**Version 0.15**
 
 BootMe is a personal productivity application that automates the setup of your work environment, allowing you to focus on what really matters. It handles opening up necessary apps, setting up your favorite music on Spotify, cleaning up your desktop, and more, all with a single command.
 

--- a/scripts/backend/config_manager.py
+++ b/scripts/backend/config_manager.py
@@ -59,6 +59,7 @@ class ConfigManager:
                     "spotify_id": ""
                 }
             ],
+            "app_folder":"",
                 "workflows": {
                     "kill_all_apps": [],
                     "clean_desktop_ignore_list": [

--- a/scripts/backend/config_manager.py
+++ b/scripts/backend/config_manager.py
@@ -59,7 +59,6 @@ class ConfigManager:
                     "spotify_id": ""
                 }
             ],
-            "app_folder":"",
                 "workflows": {
                     "kill_all_apps": [],
                     "clean_desktop_ignore_list": [

--- a/scripts/ui/environment_field_manager.py
+++ b/scripts/ui/environment_field_manager.py
@@ -11,14 +11,6 @@ class EnvironmentFieldManager:
         self.config_manager = config_manager
         self.current_config = current_config
 
-    def set_app_folder_location(self):
-        folder_path = filedialog.askdirectory(title="Select App Folder")
-        if folder_path:
-            self.current_config["app_folder"] = folder_path
-            self.config_manager.write_config(self.current_config)
-            self.app_folder_entry.delete(0, tk.END)
-            self.app_folder_entry.insert(0, folder_path)
-
     def load_environment_fields(self, index):
         environment = self.current_config["environments"][index]
 
@@ -44,30 +36,19 @@ class EnvironmentFieldManager:
         add_link_button = tk.Button(self.fields_frame, text="Add Link", command=self.add_link)
         add_link_button.grid(row=2, column=2, sticky="ew", padx=5, pady=5)
         self.links_listbox = tk.Listbox(self.fields_frame, height=4)
-        self.links_listbox.grid(row=3, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
+        self.links_listbox.grid(row=3, column=1, sticky="ew", padx=5, pady=5)
         self.links_listbox.bind("<Double-Button-1>", self.edit_link)
 
         for link in environment["links"]:
             self.links_listbox.insert(tk.END, link)
 
-        # App folder location
-        app_folder_label = tk.Label(self.fields_frame, text="App folder location:")
-        app_folder_label.grid(row=5, column=0, sticky="e", padx=5, pady=5)
-        self.app_folder_entry = tk.Entry(self.fields_frame)
-        self.app_folder_entry.grid(row=5, column=1, sticky="ew", padx=5, pady=5)
-        self.app_folder_entry.insert(0, self.current_config.get("app_folder", ""))
-        self.app_folder_button = tk.Button(self.fields_frame, text="Set App Folder", command=self.set_app_folder_location)
-        self.app_folder_button.grid(row=5, column=2, sticky="ew", padx=5, pady=5)
-
         # Apps fields
         apps_label = tk.Label(self.fields_frame, text="Apps:")
-        apps_label.grid(row=7, column=0, sticky="e", padx=5, pady=5)
-        self.app_entry = tk.Entry(self.fields_frame)
-        self.app_entry.grid(row=7, column=1, sticky="ew", padx=5, pady=5)
-        add_app_button = tk.Button(self.fields_frame, text="Add App", command=self.add_app)
-        add_app_button.grid(row=7, column=2, sticky="ew", padx=5, pady=5)
+        apps_label.grid(row=5, column=0, sticky="e", padx=5, pady=5)
         self.apps_listbox = tk.Listbox(self.fields_frame, height=4)
-        self.apps_listbox.grid(row=8, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
+        self.apps_listbox.grid(row=5, column=1, sticky="ew", padx=5, pady=5)
+        add_app_button = tk.Button(self.fields_frame, text="Add App", command=self.add_app)
+        add_app_button.grid(row=5, column=2, sticky="ew", padx=5, pady=5)
         self.apps_listbox.bind("<Double-Button-1>", self.edit_app)
 
         for app in environment["apps"]:
@@ -75,9 +56,9 @@ class EnvironmentFieldManager:
 
         # Spotify Link field
         spotify_link_label = tk.Label(self.fields_frame, text="Spotify Link:")
-        spotify_link_label.grid(row=10, column=0, sticky="e", padx=5, pady=5)
+        spotify_link_label.grid(row=7, column=0, sticky="e", padx=5, pady=5)
         self.spotify_link_entry = tk.Entry(self.fields_frame)
-        self.spotify_link_entry.grid(row=10, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
+        self.spotify_link_entry.grid(row=7, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
         self.spotify_link_entry.insert(0, environment["spotify_url"])
 
     def load_kill_all_fields(self):
@@ -131,10 +112,10 @@ class EnvironmentFieldManager:
             self.link_entry.delete(0, tk.END)
 
     def add_app(self):
-        app = self.app_entry.get()
-        if app:
-            self.apps_listbox.insert(tk.END, app)
-            self.app_entry.delete(0, tk.END)
+        app_path = filedialog.askopenfilename(title="Select App", initialdir="/Applications")
+        
+        if app_path:
+            self.apps_listbox.insert(tk.END, app_path)
 
     def add_app_kill(self):
         app = self.app_kill_entry.get()

--- a/scripts/ui/environment_field_manager.py
+++ b/scripts/ui/environment_field_manager.py
@@ -1,0 +1,231 @@
+import tkinter as tk
+from scripts.backend.config_manager import ConfigManager
+from scripts.backend.workflows import invalidate_config_cache
+from scripts.backend.spoticry import Spoticry
+from scripts.ui.edit_dialog import EditDialog
+
+class EnvironmentFieldManager:
+    def __init__(self, fields_frame, current_config, config_manager):
+        self.fields_frame = fields_frame
+        self.config_manager = config_manager
+        self.current_config = current_config
+
+    def load_environment_fields(self, index):
+        environment = self.current_config["environments"][index]
+
+        # Configure grid columns and rows to expand with the window
+        self.fields_frame.grid_columnconfigure(0, weight=1)
+        self.fields_frame.grid_columnconfigure(1, weight=2)
+        self.fields_frame.grid_columnconfigure(2, weight=1)
+        for i in range(7):  # Assuming 7 rows for this example
+            self.fields_frame.grid_rowconfigure(i, weight=1)
+
+        # Name field
+        name_label = tk.Label(self.fields_frame, text="Name:")
+        name_label.grid(row=0, column=0, sticky="e", padx=5, pady=5)
+        self.name_entry = tk.Entry(self.fields_frame)
+        self.name_entry.grid(row=0, column=1, sticky="ew", padx=5, pady=5)
+        self.name_entry.insert(0, environment["name"])
+
+        # Links fields
+        links_label = tk.Label(self.fields_frame, text="Links:")
+        links_label.grid(row=1, column=0, sticky="e", padx=5, pady=5)
+        self.link_entry = tk.Entry(self.fields_frame)
+        self.link_entry.grid(row=1, column=1, sticky="ew", padx=5, pady=5)
+        add_link_button = tk.Button(self.fields_frame, text="Add Link", command=self.add_link)
+        add_link_button.grid(row=1, column=2, sticky="ew", padx=5, pady=5)
+        self.links_listbox = tk.Listbox(self.fields_frame, height=4)
+        self.links_listbox.grid(row=2, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
+        self.links_listbox.bind("<Double-Button-1>", self.edit_link)
+
+        for link in environment["links"]:
+            self.links_listbox.insert(tk.END, link)
+
+        # Apps fields
+        apps_label = tk.Label(self.fields_frame, text="Apps:")
+        apps_label.grid(row=3, column=0, sticky="e", padx=5, pady=5)
+        self.app_entry = tk.Entry(self.fields_frame)
+        self.app_entry.grid(row=3, column=1, sticky="ew", padx=5, pady=5)
+        add_app_button = tk.Button(self.fields_frame, text="Add App", command=self.add_app)
+        add_app_button.grid(row=3, column=2, sticky="ew", padx=5, pady=5)
+        self.apps_listbox = tk.Listbox(self.fields_frame, height=4)
+        self.apps_listbox.grid(row=4, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
+        self.apps_listbox.bind("<Double-Button-1>", self.edit_app)
+
+        for app in environment["apps"]:
+            self.apps_listbox.insert(tk.END, app)
+
+        # Spotify Link field
+        spotify_link_label = tk.Label(self.fields_frame, text="Spotify Link:")
+        spotify_link_label.grid(row=5, column=0, sticky="e", padx=5, pady=5)
+        self.spotify_link_entry = tk.Entry(self.fields_frame)
+        self.spotify_link_entry.grid(row=5, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
+        self.spotify_link_entry.insert(0, environment["spotify_url"])
+
+    def load_kill_all_fields(self):
+        # Configure grid columns and rows to expand with the window
+        self.fields_frame.grid_columnconfigure(0, weight=1)
+        self.fields_frame.grid_columnconfigure(1, weight=2)
+        self.fields_frame.grid_columnconfigure(2, weight=1)
+        for i in range(3):  # Assuming 3 rows for this method
+            self.fields_frame.grid_rowconfigure(i, weight=1)
+
+        # Apps fields
+        apps_label = tk.Label(self.fields_frame, text="Apps to Kill:")
+        apps_label.grid(row=0, column=0, sticky="e", padx=5, pady=5)
+        self.app_kill_entry = tk.Entry(self.fields_frame)
+        self.app_kill_entry.grid(row=0, column=1, sticky="ew", padx=5, pady=5)
+        add_app_kill_button = tk.Button(self.fields_frame, text="Add App", command=self.add_app_kill)
+        add_app_kill_button.grid(row=0, column=2, sticky="ew", padx=5, pady=5)
+        self.apps_kill_listbox = tk.Listbox(self.fields_frame, height=4)
+        self.apps_kill_listbox.grid(row=1, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
+        self.apps_kill_listbox.bind("<Double-Button-1>", self.edit_app_kill)
+
+        for app in self.current_config["workflows"]["kill_all_apps"]:
+            self.apps_kill_listbox.insert(tk.END, app)
+
+    def load_clean_desktop_fields(self):
+        # Configure grid columns and rows to expand with the window
+        self.fields_frame.grid_columnconfigure(0, weight=1)
+        self.fields_frame.grid_columnconfigure(1, weight=2)
+        self.fields_frame.grid_columnconfigure(2, weight=1)
+        for i in range(3):  # Assuming 3 rows for this method
+            self.fields_frame.grid_rowconfigure(i, weight=1)
+
+        # Ignore files fields
+        ignore_files_label = tk.Label(self.fields_frame, text="Files to Ignore:")
+        ignore_files_label.grid(row=0, column=0, sticky="e", padx=5, pady=5)
+        self.files_ignore_entry = tk.Entry(self.fields_frame)
+        self.files_ignore_entry.grid(row=0, column=1, sticky="ew", padx=5, pady=5)
+        add_file_ignore_button = tk.Button(self.fields_frame, text="Add File/Folder", command=self.add_file_ignore)
+        add_file_ignore_button.grid(row=0, column=2, sticky="ew", padx=5, pady=5)
+        self.files_ignore_listbox = tk.Listbox(self.fields_frame, height=4)
+        self.files_ignore_listbox.grid(row=1, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
+        self.files_ignore_listbox.bind("<Double-Button-1>", self.edit_file_ignore)
+
+        for file_or_folder in self.current_config["workflows"]["clean_desktop_ignore_list"]:
+            self.files_ignore_listbox.insert(tk.END, file_or_folder)
+
+    def add_link(self):
+        link = self.link_entry.get()
+        if link:
+            self.links_listbox.insert(tk.END, link)
+            self.link_entry.delete(0, tk.END)
+
+    def add_app(self):
+        app = self.app_entry.get()
+        if app:
+            self.apps_listbox.insert(tk.END, app)
+            self.app_entry.delete(0, tk.END)
+
+    def add_app_kill(self):
+        app = self.app_kill_entry.get()
+        if app:
+            self.apps_kill_listbox.insert(tk.END, app)
+            self.app_kill_entry.delete(0, tk.END)
+
+    def add_file_ignore(self):
+        app = self.files_ignore_entry.get()
+        if app:
+            self.files_ignore_listbox.insert(tk.END, app)
+            self.files_ignore_entry.delete(0, tk.END)
+
+    def edit_link(self, event):
+        selected_index = self.links_listbox.curselection()
+        if not selected_index:
+            return
+        selected_link = self.links_listbox.get(selected_index)
+        edit_dialog = EditDialog(self.fields_frame, "Edit Link", selected_link)
+
+        if edit_dialog.delete_flag:
+            self.links_listbox.delete(selected_index)
+        elif edit_dialog.result_value and edit_dialog.result_value != selected_link:
+            self.links_listbox.delete(selected_index)
+            self.links_listbox.insert(selected_index, edit_dialog.result_value)
+
+    def edit_app(self, event):
+        selected_index = self.apps_listbox.curselection()
+        if not selected_index:
+            return
+        selected_app = self.apps_listbox.get(selected_index)
+        edit_dialog = EditDialog(self.fields_frame, "Edit App", selected_app)
+
+        if edit_dialog.delete_flag:
+            self.apps_listbox.delete(selected_index)
+        elif edit_dialog.result_value and edit_dialog.result_value != selected_app:
+            self.apps_listbox.delete(selected_index)
+            self.apps_listbox.insert(selected_index, edit_dialog.result_value)
+
+    def edit_app_kill(self, event):
+        selected_index = self.apps_kill_listbox.curselection()
+        if not selected_index:
+            return
+        selected_app = self.apps_kill_listbox.get(selected_index)
+        edit_dialog = EditDialog(self.fields_frame, "Edit App to Quit", selected_app)
+        
+        if edit_dialog.delete_flag:
+            self.apps_kill_listbox.delete(selected_index)
+        elif edit_dialog.result_value and edit_dialog.result_value != selected_app:
+            self.apps_kill_listbox.delete(selected_index)
+            self.apps_kill_listbox.insert(selected_index, edit_dialog.result_value)
+
+    def edit_file_ignore(self, event):
+        selected_index = self.files_ignore_listbox.curselection()
+        if not selected_index:
+            return
+        selected_app = self.files_ignore_listbox.get(selected_index)
+        edit_dialog = EditDialog(self.fields_frame, "Edit file to ignore", selected_app)
+        
+        if edit_dialog.delete_flag:
+            self.files_ignore_listbox.delete(selected_index)
+        elif edit_dialog.result_value and edit_dialog.result_value != selected_app:
+            self.files_ignore_listbox.delete(selected_index)
+            self.files_ignore_listbox.insert(selected_index, edit_dialog.result_value)
+
+    def save_config(self, selection):
+        envs = self.current_config["environments"]
+        names = [env["name"] for env in envs]
+        names.append("Kill All")
+        names.append("Clean Desktop")
+
+        index = names.index(selection)
+
+        if index < 4:
+            # Read the data from UI fields
+            name = self.name_entry.get()
+            links = [self.links_listbox.get(i) for i in range(self.links_listbox.size())]
+            apps = [self.apps_listbox.get(i) for i in range(self.apps_listbox.size())]
+            spotify_play = bool(self.spotify_link_entry.get().strip())
+            spotify_link = self.spotify_link_entry.get() if spotify_play else ""
+            
+            # Update the current_config dictionary
+            self.current_config["environments"][index]["name"] = name
+            self.current_config["environments"][index]["links"] = links
+            self.current_config["environments"][index]["apps"] = apps
+
+            spoticry = Spoticry()
+
+            if spotify_play:
+                self.current_config["environments"][index]["spotify_url"] = spotify_link
+                play_data = spoticry.parse_link(spotify_link)
+                self.current_config["environments"][index]["spotify_type"] = play_data[0]
+                self.current_config["environments"][index]["spotify_id"] = play_data[1]
+            else:
+                self.current_config["environments"][index]["spotify_url"] = ""
+                self.current_config["environments"][index]["spotify_type"] = ""
+                self.current_config["environments"][index]["spotify_id"] = ""
+            
+        elif selection == "Kill All":
+            # Read the data from UI fields
+            apps_to_kill = [self.apps_kill_listbox.get(i) for i in range(self.apps_kill_listbox.size())]
+            self.current_config["workflows"]["kill_all_apps"] = apps_to_kill
+        
+        elif selection == "Clean Desktop":
+            # Read the data from UI fields
+            files_to_ignore = [self.files_ignore_listbox.get(i) for i in range(self.files_ignore_listbox.size())]
+            self.current_config["workflows"]["clean_desktop_ignore_list"] = files_to_ignore
+        
+        # Save the updated config using config_manager
+        self.config_manager.write_config(self.current_config)
+        invalidate_config_cache()
+        tk.messagebox.showinfo("Saved", "Configuration saved successfully!")

--- a/scripts/ui/environment_field_manager.py
+++ b/scripts/ui/environment_field_manager.py
@@ -1,4 +1,5 @@
 import tkinter as tk
+from tkinter import filedialog
 from scripts.backend.config_manager import ConfigManager
 from scripts.backend.workflows import invalidate_config_cache
 from scripts.backend.spoticry import Spoticry
@@ -10,6 +11,14 @@ class EnvironmentFieldManager:
         self.config_manager = config_manager
         self.current_config = current_config
 
+    def set_app_folder_location(self):
+        folder_path = filedialog.askdirectory(title="Select App Folder")
+        if folder_path:
+            self.current_config["app_folder"] = folder_path
+            self.config_manager.write_config(self.current_config)
+            self.app_folder_entry.delete(0, tk.END)
+            self.app_folder_entry.insert(0, folder_path)
+
     def load_environment_fields(self, index):
         environment = self.current_config["environments"][index]
 
@@ -17,7 +26,7 @@ class EnvironmentFieldManager:
         self.fields_frame.grid_columnconfigure(0, weight=1)
         self.fields_frame.grid_columnconfigure(1, weight=2)
         self.fields_frame.grid_columnconfigure(2, weight=1)
-        for i in range(7):  # Assuming 7 rows for this example
+        for i in range(8):
             self.fields_frame.grid_rowconfigure(i, weight=1)
 
         # Name field
@@ -29,27 +38,36 @@ class EnvironmentFieldManager:
 
         # Links fields
         links_label = tk.Label(self.fields_frame, text="Links:")
-        links_label.grid(row=1, column=0, sticky="e", padx=5, pady=5)
+        links_label.grid(row=2, column=0, sticky="e", padx=5, pady=5)
         self.link_entry = tk.Entry(self.fields_frame)
-        self.link_entry.grid(row=1, column=1, sticky="ew", padx=5, pady=5)
+        self.link_entry.grid(row=2, column=1, sticky="ew", padx=5, pady=5)
         add_link_button = tk.Button(self.fields_frame, text="Add Link", command=self.add_link)
-        add_link_button.grid(row=1, column=2, sticky="ew", padx=5, pady=5)
+        add_link_button.grid(row=2, column=2, sticky="ew", padx=5, pady=5)
         self.links_listbox = tk.Listbox(self.fields_frame, height=4)
-        self.links_listbox.grid(row=2, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
+        self.links_listbox.grid(row=3, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
         self.links_listbox.bind("<Double-Button-1>", self.edit_link)
 
         for link in environment["links"]:
             self.links_listbox.insert(tk.END, link)
 
+        # App folder location
+        app_folder_label = tk.Label(self.fields_frame, text="App folder location:")
+        app_folder_label.grid(row=5, column=0, sticky="e", padx=5, pady=5)
+        self.app_folder_entry = tk.Entry(self.fields_frame)
+        self.app_folder_entry.grid(row=5, column=1, sticky="ew", padx=5, pady=5)
+        self.app_folder_entry.insert(0, self.current_config.get("app_folder", ""))
+        self.app_folder_button = tk.Button(self.fields_frame, text="Set App Folder", command=self.set_app_folder_location)
+        self.app_folder_button.grid(row=5, column=2, sticky="ew", padx=5, pady=5)
+
         # Apps fields
         apps_label = tk.Label(self.fields_frame, text="Apps:")
-        apps_label.grid(row=3, column=0, sticky="e", padx=5, pady=5)
+        apps_label.grid(row=7, column=0, sticky="e", padx=5, pady=5)
         self.app_entry = tk.Entry(self.fields_frame)
-        self.app_entry.grid(row=3, column=1, sticky="ew", padx=5, pady=5)
+        self.app_entry.grid(row=7, column=1, sticky="ew", padx=5, pady=5)
         add_app_button = tk.Button(self.fields_frame, text="Add App", command=self.add_app)
-        add_app_button.grid(row=3, column=2, sticky="ew", padx=5, pady=5)
+        add_app_button.grid(row=7, column=2, sticky="ew", padx=5, pady=5)
         self.apps_listbox = tk.Listbox(self.fields_frame, height=4)
-        self.apps_listbox.grid(row=4, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
+        self.apps_listbox.grid(row=8, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
         self.apps_listbox.bind("<Double-Button-1>", self.edit_app)
 
         for app in environment["apps"]:
@@ -57,9 +75,9 @@ class EnvironmentFieldManager:
 
         # Spotify Link field
         spotify_link_label = tk.Label(self.fields_frame, text="Spotify Link:")
-        spotify_link_label.grid(row=5, column=0, sticky="e", padx=5, pady=5)
+        spotify_link_label.grid(row=10, column=0, sticky="e", padx=5, pady=5)
         self.spotify_link_entry = tk.Entry(self.fields_frame)
-        self.spotify_link_entry.grid(row=5, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
+        self.spotify_link_entry.grid(row=10, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
         self.spotify_link_entry.insert(0, environment["spotify_url"])
 
     def load_kill_all_fields(self):

--- a/scripts/ui/settings_ui_manager.py
+++ b/scripts/ui/settings_ui_manager.py
@@ -6,7 +6,7 @@ from scripts.ui.environment_field_manager import EnvironmentFieldManager
 class SettingsUIManager:
     def __init__(self, root, config_manager):
         self.root = root
-        self.root.geometry("550x450")
+        self.root.geometry("600x500")
         self.config_manager = config_manager
         self.current_config = self.config_manager.read_config()
         self.fields_frame = tk.Frame(self.root)

--- a/scripts/ui/settings_ui_manager.py
+++ b/scripts/ui/settings_ui_manager.py
@@ -1,9 +1,7 @@
 import tkinter as tk
 from tkinter import ttk, simpledialog
 from scripts.backend.config_manager import ConfigManager
-from scripts.backend.spoticry import Spoticry
-from scripts.ui.edit_dialog import EditDialog
-from scripts.backend.workflows import invalidate_config_cache
+from scripts.ui.environment_field_manager import EnvironmentFieldManager
 
 class SettingsUIManager:
     def __init__(self, root, config_manager):
@@ -11,25 +9,47 @@ class SettingsUIManager:
         self.root.geometry("550x450")
         self.config_manager = config_manager
         self.current_config = self.config_manager.read_config()
-
+        self.fields_frame = tk.Frame(self.root)
+        self.fields_frame.pack(pady=20, padx=20)
+        self.env_field_manager = EnvironmentFieldManager(self.fields_frame, self.current_config, self.config_manager)
+        self.BACKGROUND_COLOR = '#a9927d'
+        self.FOREGROUND_COLOR = '#5c5241'
         self.build_ui()
 
     def build_ui(self):
-        self.selection_var = tk.StringVar()
+        # Set the background color for the main window
+        self.root.configure(bg=self.BACKGROUND_COLOR)
 
+        # Create a top frame to hold the dropdown
+        top_frame = tk.Frame(self.root, bg=self.BACKGROUND_COLOR)
+        top_frame.pack(pady=10, padx=20, fill=tk.X)
+
+        self.selection_var = tk.StringVar()
         envs = self.current_config["environments"]
         options = [env["name"] for env in envs]
         options.append("Kill All")
         options.append("Clean Desktop")
-        self.selection_dropdown = ttk.Combobox(self.root, textvariable=self.selection_var, values=options)
+
+        # Pack the selection dropdown inside the top frame
+        self.selection_dropdown = ttk.Combobox(top_frame, textvariable=self.selection_var, values=options)
         self.selection_dropdown.bind("<<ComboboxSelected>>", self.load_fields_for_selection)
-        self.selection_dropdown.pack(pady=10)
+        self.selection_dropdown.pack(pady=5, padx=10, anchor='center')
 
-        self.fields_frame = tk.Frame(self.root)
-        self.fields_frame.pack(pady=20, padx=20)
+        # Configure and pack the fields_frame
+        self.fields_frame.configure(bg=self.BACKGROUND_COLOR)
+        self.fields_frame.pack(pady=20, padx=20, expand=True, fill=tk.BOTH)
 
-        self.save_button = tk.Button(self.root, text="Save Config", command=self.save_config)
-        self.save_button.pack(pady=10)
+        # Pack the save_button
+        self.save_button = tk.Button(self.root, text="Save Config", 
+                                    bg=self.BACKGROUND_COLOR, 
+                                    fg=self.FOREGROUND_COLOR, 
+                                    command=lambda: 
+                                        self.env_field_manager.save_config(self.selection_var.get()))
+        self.save_button.pack(pady=10, anchor='center')
+
+        # Ensure the main window and its widgets resize appropriately
+        self.root.grid_rowconfigure(0, weight=1)
+        self.root.grid_columnconfigure(0, weight=1)
 
     def load_fields_for_selection(self, event=None):
         for widget in self.fields_frame.winfo_children():
@@ -43,208 +63,8 @@ class SettingsUIManager:
         names.append("Clean Desktop")
         index = names.index(selection)
         if index < 4:
-            self.load_environment_fields(index)
+            self.env_field_manager.load_environment_fields(index)
         elif index == 4:
-            self.load_kill_all_fields()
+            self.env_field_manager.load_kill_all_fields()
         else:
-            self.load_clean_desktop_fields()
-
-    def load_environment_fields(self, index):
-        environment = self.current_config["environments"][index]
-
-        # Name field
-        name_label = tk.Label(self.fields_frame, text="Name:")
-        name_label.grid(row=0, column=0, sticky="e")
-        self.name_entry = tk.Entry(self.fields_frame)
-        self.name_entry.grid(row=0, column=1, columnspan=2)
-        self.name_entry.insert(0, environment["name"])
-
-        # Links fields
-        links_label = tk.Label(self.fields_frame, text="Links:")
-        links_label.grid(row=1, column=0, sticky="e")
-        self.link_entry = tk.Entry(self.fields_frame)
-        self.link_entry.grid(row=1, column=1)
-        add_link_button = tk.Button(self.fields_frame, text="Add Link", command=self.add_link)
-        add_link_button.grid(row=1, column=2)
-        self.links_listbox = tk.Listbox(self.fields_frame, height=4)
-        self.links_listbox.grid(row=2, column=1, columnspan=2, pady=5)
-        self.links_listbox.bind("<Double-Button-1>", self.edit_link)
-
-        for link in environment["links"]:
-            self.links_listbox.insert(tk.END, link)
-
-        # Apps fields
-        apps_label = tk.Label(self.fields_frame, text="Apps:")
-        apps_label.grid(row=3, column=0, sticky="e")
-        self.app_entry = tk.Entry(self.fields_frame)
-        self.app_entry.grid(row=3, column=1)
-        add_app_button = tk.Button(self.fields_frame, text="Add App", command=self.add_app)
-        add_app_button.grid(row=3, column=2)
-        self.apps_listbox = tk.Listbox(self.fields_frame, height=4)
-        self.apps_listbox.grid(row=4, column=1, columnspan=2, pady=5)
-        self.apps_listbox.bind("<Double-Button-1>", self.edit_app) 
-
-        for app in environment["apps"]:
-            self.apps_listbox.insert(tk.END, app)
-
-        spotify_link_label = tk.Label(self.fields_frame, text="Spotify Link:")
-        spotify_link_label.grid(row=6, column=0, sticky="e")
-        self.spotify_link_entry = tk.Entry(self.fields_frame)
-        self.spotify_link_entry.grid(row=6, column=1, columnspan=2)
-        self.spotify_link_entry.insert(0, environment["spotify_url"])
-
-    def load_kill_all_fields(self):
-        # Apps fields
-        apps_label = tk.Label(self.fields_frame, text="Apps to Kill:")
-        apps_label.grid(row=1, column=0, sticky="e")
-        self.app_kill_entry = tk.Entry(self.fields_frame)
-        self.app_kill_entry.grid(row=1, column=1)
-        add_app_kill_button = tk.Button(self.fields_frame, text="Add App", command=self.add_app_kill)
-        add_app_kill_button.grid(row=1, column=2)
-        self.apps_kill_listbox = tk.Listbox(self.fields_frame, height=4)
-        self.apps_kill_listbox.grid(row=2, column=1, columnspan=2, pady=5)
-        self.apps_kill_listbox.bind("<Double-Button-1>", self.edit_app_kill)
-        
-        for app in self.current_config["workflows"]["kill_all_apps"]:
-            self.apps_kill_listbox.insert(tk.END, app)
-
-    def load_clean_desktop_fields(self):
-        # Ignore files fields
-        ignore_files_label = tk.Label(self.fields_frame, text="Files to Ignore:")
-        ignore_files_label.grid(row=1, column=0, sticky="e")
-        self.files_ignore_entry = tk.Entry(self.fields_frame)
-        self.files_ignore_entry.grid(row=1, column=1)
-        add_file_ignore_button = tk.Button(self.fields_frame, text="Add File/Folder", command=self.add_file_ignore)
-        add_file_ignore_button.grid(row=1, column=2)
-        self.files_ignore_listbox = tk.Listbox(self.fields_frame, height=4)
-        self.files_ignore_listbox.grid(row=2, column=1, columnspan=2, pady=5)
-        self.files_ignore_listbox.bind("<Double-Button-1>", self.edit_file_ignore)
-
-        for file_or_folder in self.current_config["workflows"]["clean_desktop_ignore_list"]:
-            self.files_ignore_listbox.insert(tk.END, file_or_folder)
-
-    def add_link(self):
-        link = self.link_entry.get()
-        if link:
-            self.links_listbox.insert(tk.END, link)
-            self.link_entry.delete(0, tk.END)
-
-    def add_app(self):
-        app = self.app_entry.get()
-        if app:
-            self.apps_listbox.insert(tk.END, app)
-            self.app_entry.delete(0, tk.END)
-
-    def add_app_kill(self):
-        app = self.app_kill_entry.get()
-        if app:
-            self.apps_kill_listbox.insert(tk.END, app)
-            self.app_kill_entry.delete(0, tk.END)
-
-    def add_file_ignore(self):
-        app = self.files_ignore_entry.get()
-        if app:
-            self.files_ignore_listbox.insert(tk.END, app)
-            self.files_ignore_entry.delete(0, tk.END)
-
-    def edit_link(self, event):
-        selected_index = self.links_listbox.curselection()
-        if not selected_index:
-            return
-        selected_link = self.links_listbox.get(selected_index)
-        edit_dialog = EditDialog(self.root, "Edit Link", selected_link)
-
-        if edit_dialog.delete_flag:
-            self.links_listbox.delete(selected_index)
-        elif edit_dialog.result_value and edit_dialog.result_value != selected_link:
-            self.links_listbox.delete(selected_index)
-            self.links_listbox.insert(selected_index, edit_dialog.result_value)
-
-    def edit_app(self, event):
-        selected_index = self.apps_listbox.curselection()
-        if not selected_index:
-            return
-        selected_app = self.apps_listbox.get(selected_index)
-        edit_dialog = EditDialog(self.root, "Edit App", selected_app)
-
-        if edit_dialog.delete_flag:
-            self.apps_listbox.delete(selected_index)
-        elif edit_dialog.result_value and edit_dialog.result_value != selected_app:
-            self.apps_listbox.delete(selected_index)
-            self.apps_listbox.insert(selected_index, edit_dialog.result_value)
-
-    def edit_app_kill(self, event):
-        selected_index = self.apps_kill_listbox.curselection()
-        if not selected_index:
-            return
-        selected_app = self.apps_kill_listbox.get(selected_index)
-        edit_dialog = EditDialog(self.root, "Edit App to Quit", selected_app)
-        
-        if edit_dialog.delete_flag:
-            self.apps_kill_listbox.delete(selected_index)
-        elif edit_dialog.result_value and edit_dialog.result_value != selected_app:
-            self.apps_kill_listbox.delete(selected_index)
-            self.apps_kill_listbox.insert(selected_index, edit_dialog.result_value)
-
-    def edit_file_ignore(self, event):
-        selected_index = self.files_ignore_listbox.curselection()
-        if not selected_index:
-            return
-        selected_app = self.files_ignore_listbox.get(selected_index)
-        edit_dialog = EditDialog(self.root, "Edit file to ignore", selected_app)
-        
-        if edit_dialog.delete_flag:
-            self.files_ignore_listbox.delete(selected_index)
-        elif edit_dialog.result_value and edit_dialog.result_value != selected_app:
-            self.files_ignore_listbox.delete(selected_index)
-            self.files_ignore_listbox.insert(selected_index, edit_dialog.result_value)
-
-    def save_config(self):
-        selection = self.selection_var.get()
-
-        envs = self.current_config["environments"]
-        names = [env["name"] for env in envs]
-        names.append("Kill All")
-        names.append("Clean Desktop")
-
-        index = names.index(selection)
-
-        if index < 4:
-            # Read the data from UI fields
-            name = self.name_entry.get()
-            links = [self.links_listbox.get(i) for i in range(self.links_listbox.size())]
-            apps = [self.apps_listbox.get(i) for i in range(self.apps_listbox.size())]
-            spotify_play = bool(self.spotify_link_entry.get().strip())
-            spotify_link = self.spotify_link_entry.get() if spotify_play else ""
-            
-            # Update the current_config dictionary
-            self.current_config["environments"][index]["name"] = name
-            self.current_config["environments"][index]["links"] = links
-            self.current_config["environments"][index]["apps"] = apps
-
-            spoticry = Spoticry()
-
-            if spotify_play:
-                self.current_config["environments"][index]["spotify_url"] = spotify_link
-                play_data = spoticry.parse_link(spotify_link)
-                self.current_config["environments"][index]["spotify_type"] = play_data[0]
-                self.current_config["environments"][index]["spotify_id"] = play_data[1]
-            else:
-                self.current_config["environments"][index]["spotify_url"] = ""
-                self.current_config["environments"][index]["spotify_type"] = ""
-                self.current_config["environments"][index]["spotify_id"] = ""
-            
-        elif selection == "Kill All":
-            # Read the data from UI fields
-            apps_to_kill = [self.apps_kill_listbox.get(i) for i in range(self.apps_kill_listbox.size())]
-            self.current_config["workflows"]["kill_all_apps"] = apps_to_kill
-        
-        elif selection == "Clean Desktop":
-            # Read the data from UI fields
-            files_to_ignore = [self.files_ignore_listbox.get(i) for i in range(self.files_ignore_listbox.size())]
-            self.current_config["workflows"]["clean_desktop_ignore_list"] = files_to_ignore
-        
-        # Save the updated config using config_manager
-        self.config_manager.write_config(self.current_config)
-        invalidate_config_cache()
-        tk.messagebox.showinfo("Saved", "Configuration saved successfully!")
+            self.env_field_manager.load_clean_desktop_fields()


### PR DESCRIPTION
### Description

Please include a summary of the change and which issue is fixed or feature is introduced. Please also include relevant motivation and context.

Fixes #20 #23 

### Summary

There are a lot of changes. Firstly, I modularized `settings_ui_manager`. I moved anything related to configuring the buttons and added it to a new module called `environment_field_manger`. The purpose of `environment_field_manager` is to load the environment fields, allow updates and customization for the buttons. `settings_ui_manager` is now only built to handle the main UI for the settings window. 

I also updated the settings window UI. 

Next, I found a more elegant solution to launching apps. Before, we required users to type the exact path to the app they wanted to launch. For example `/Applications/Notion.app`; however, this isn't user-friendly. The approach to fix this was to allow users to set a default application location and save that to the `config.json`. This would allow users to select the location for their applications and then they would be able to simply type `notion`. This would require sanitizing and appending that to the set app location. This solution does not work very well because we'd need to assume that all apps are in a specific format. for example, the app `iTerm` might turn into `Iterm` which is not correct. A better and more elegant solution is to allow users to communicate with the file system directly and choose the app they want to launch. This would then remove the need for setting a default applications folder and worry about user mistakes. 

Now the user simply clicks "Add App" and they would be able to directly choose what app they want to launch instead. 

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation the user needs to know)

### Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

I ran regression tests by removing the config.json and ensuring that we would still create a default config.json of the correct format. I then added new links, removed links, added apps with the new implementation, removed apps, and added spotify links. Everything seems to work well. 

There was a bug discovered that will need to be fixed. If the user changes the name of the button and saved the configuration it will cause problems when trying to reselect the configuration because the new name is not updated in the selection. To reproduce: 

Click on settings -> rename an environment (standard environment to testing) -> save config -> reselect the button and it will throw errors that "standard environment" does not exist in config.json. 

This needs to be fixed later. 

### Additional Context (optional)

