### PR TITLE
enhancement<settings, ui>: Displays spotify name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BootMe
-**Version 0.16.0**
+**Version 0.17.0**
 
 BootMe is a personal productivity application that automates the setup of your work environment, allowing you to focus on what really matters. It handles opening up necessary apps, setting up your favorite music on Spotify, cleaning up your desktop, and more, all with a single command.
 

--- a/scripts/backend/config_manager.py
+++ b/scripts/backend/config_manager.py
@@ -24,7 +24,8 @@ class ConfigManager:
                     "apps": [],
                     "spotify_url": "",
                     "spotify_type": "",
-                    "spotify_id": ""
+                    "spotify_id": "",
+                    "spotify_display_name": ""
                 },
                 {
                     "name": "Recruiting Environment",
@@ -36,7 +37,8 @@ class ConfigManager:
                     "apps": [],
                     "spotify_url": "",
                     "spotify_type": "",
-                    "spotify_id": ""
+                    "spotify_id": "",
+                    "spotify_display_name": ""
                 },
                 {
                     "name": "Extra Environment 1",
@@ -46,7 +48,8 @@ class ConfigManager:
                     "apps": [],
                     "spotify_url": "",
                     "spotify_type": "",
-                    "spotify_id": ""
+                    "spotify_id": "",
+                    "spotify_display_name": ""
                 },
                 {
                     "name": "Extra Environment 2",
@@ -56,7 +59,8 @@ class ConfigManager:
                     "apps": [],
                     "spotify_url": "",
                     "spotify_type": "",
-                    "spotify_id": ""
+                    "spotify_id": "",
+                    "spotify_display_name": ""
                 }
             ],
                 "workflows": {
@@ -72,6 +76,13 @@ class ConfigManager:
     def get_all_names(self):
         config_data = self.read_config()
         return [env["name"] for env in config_data.get("environments", [])]
+    
+    def get_display_name(self, environment_name):
+        config_data = self.read_config()
+        for env in config_data.get("environments", []):
+            if env["name"] == environment_name:
+                return env.get("display_name", "")
+        return ""
 
     def read_config(self):
         if not os.path.exists(self.config_path):

--- a/scripts/backend/spoticry.py
+++ b/scripts/backend/spoticry.py
@@ -55,3 +55,16 @@ class Spoticry:
         results = self.sp.album_tracks(album_id)
         track_uids = [track["uri"] for track in results["items"]]
         self.sp.start_playback(uris=track_uids)
+
+    def get_name(self, spotify_link):
+        link_type, id = self.parse_link(spotify_link)
+        
+        if link_type == "playlist":
+            playlist_info = self.sp.playlist(playlist_id=id)
+            return playlist_info["name"]
+        elif link_type == "album":
+            album_info = self.sp.album(album_id=id)
+            return album_info["name"]
+        else:
+            return None
+

--- a/scripts/ui/environment_field_manager.py
+++ b/scripts/ui/environment_field_manager.py
@@ -64,6 +64,23 @@ class EnvironmentFieldManager:
         self.spotify_link_entry.grid(row=7, column=1, columnspan=2, sticky="ew", padx=5, pady=5)
         self.spotify_link_entry.insert(0, environment["spotify_url"])
 
+        # Spotify Display Name field
+        spotify_display_name_label = tk.Label(
+            self.fields_frame, text="Spotify Display Name:"
+        )
+
+        spotify_display_name_label.grid(row=8, column=0, sticky="e", padx=5, pady=5)
+        self.spotify_display_name_entry = tk.Entry(self.fields_frame)
+        self.spotify_display_name_entry.grid(
+            row=8, column=1, 
+            columnspan=2, sticky="ew", 
+            padx=5, pady=5
+        )
+        
+        # Load the Spotify display name from the configuration
+        spotify_display_name = environment.get("spotify_display_name", "")
+        self.spotify_display_name_entry.insert(0, spotify_display_name)
+
     def load_kill_all_fields(self):
         # Configure grid columns and rows to expand with the window
         self.fields_frame.grid_columnconfigure(0, weight=1)
@@ -82,7 +99,12 @@ class EnvironmentFieldManager:
         self.apps_kill_listbox.bind("<Double-Button-1>", self.edit_app_kill)
 
         # Move the "Add App" button up to row 0, column 2
-        add_app_kill_button = tk.Button(self.fields_frame, text="Add App", command=self.add_app_kill)
+        add_app_kill_button = tk.Button(
+            self.fields_frame,
+            text="Add App",
+            command=self.add_app_kill
+        )
+
         add_app_kill_button.grid(row=0, column=2, sticky="ew", padx=5, pady=5)
 
         for app in self.current_config["workflows"]["kill_all_apps"]:
@@ -106,7 +128,11 @@ class EnvironmentFieldManager:
         self.files_ignore_listbox.grid(row=0, column=1, sticky="nsew", padx=5, pady=5)
         self.files_ignore_listbox.bind("<Double-Button-1>", self.edit_file_ignore)
 
-        add_file_folder_button = tk.Button(self.fields_frame, text="Add File/Folder", command=self.select_file_or_folder)
+        add_file_folder_button = tk.Button(
+            self.fields_frame, text="Add File/Folder",
+            command=self.select_file_or_folder
+        )
+        
         add_file_folder_button.grid(row=0, column=2, sticky="ew", padx=5, pady=5)
 
         for file_or_folder in self.current_config["workflows"]["clean_desktop_ignore_list"]:
@@ -127,7 +153,9 @@ class EnvironmentFieldManager:
         else:
             # For Linux or other OS, default or handle differently
             applications_path = os.path.expanduser("~")
-        app_path = filedialog.askopenfilename(title="Select App", initialdir=applications_path)
+        app_path = filedialog.askopenfilename(
+            title="Select App", initialdir=applications_path
+        )
         
         if app_path and app_path not in self.apps_listbox.get(0, tk.END):
             self.apps_listbox.insert(tk.END, app_path)
@@ -151,7 +179,9 @@ class EnvironmentFieldManager:
         else:
             applications_path = os.path.expanduser("~")
         
-        app_path = filedialog.askopenfilename(title="Select App to Kill", initialdir=applications_path)
+        app_path = filedialog.askopenfilename(
+            title="Select App to Kill", initialdir=applications_path
+        )
         
         app_name = self.sanitize_path(app_path, True)
         
@@ -164,7 +194,10 @@ class EnvironmentFieldManager:
         menu.add_command(label="Select File", command=self.select_file)
         menu.add_command(label="Select Folder", command=self.select_folder)
         
-        menu.post(self.fields_frame.winfo_pointerx(), self.fields_frame.winfo_pointery())
+        menu.post(
+            self.fields_frame.winfo_pointerx(), 
+            self.fields_frame.winfo_pointery()
+        )
 
     def select_file(self):
         desktop_path = os.path.join(os.path.expanduser("~"), "Desktop")
@@ -257,7 +290,7 @@ class EnvironmentFieldManager:
             apps = [self.apps_listbox.get(i) for i in range(self.apps_listbox.size())]
             spotify_play = bool(self.spotify_link_entry.get().strip())
             spotify_link = self.spotify_link_entry.get() if spotify_play else ""
-            
+
             # Update the current_config dictionary
             self.current_config["environments"][index]["name"] = name
             self.current_config["environments"][index]["links"] = links
@@ -270,18 +303,22 @@ class EnvironmentFieldManager:
                 play_data = spoticry.parse_link(spotify_link)
                 self.current_config["environments"][index]["spotify_type"] = play_data[0]
                 self.current_config["environments"][index]["spotify_id"] = play_data[1]
+                
+                spotify_display_name = spoticry.get_name(spotify_link)
+                self.current_config["environments"][index]["spotify_display_name"] = spotify_display_name
+
+                self.spotify_display_name_entry.delete(0, tk.END)
+                self.spotify_display_name_entry.insert(0, spotify_display_name)
             else:
                 self.current_config["environments"][index]["spotify_url"] = ""
                 self.current_config["environments"][index]["spotify_type"] = ""
                 self.current_config["environments"][index]["spotify_id"] = ""
+                self.current_config["environments"][index]["spotify_display_name"] = ""
             
         elif selection == "Kill All":
-            # Read the data from UI fields
             apps_to_kill = [self.apps_kill_listbox.get(i) for i in range(self.apps_kill_listbox.size())]
             self.current_config["workflows"]["kill_all_apps"] = apps_to_kill
-        
         elif selection == "Clean Desktop":
-            # Read the data from UI fields
             files_to_ignore = [self.files_ignore_listbox.get(i) for i in range(self.files_ignore_listbox.size())]
             self.current_config["workflows"]["clean_desktop_ignore_list"] = files_to_ignore
         

--- a/scripts/ui/settings_ui_manager.py
+++ b/scripts/ui/settings_ui_manager.py
@@ -17,8 +17,8 @@ class SettingsUIManager:
             self.config_manager,
             save_callback=self.refresh_dropdown
         )
-        self.BACKGROUND_COLOR = '#a9927d'
-        self.FOREGROUND_COLOR = '#5c5241'
+        self.BACKGROUND_COLOR = "#a9927d"
+        self.FOREGROUND_COLOR = "#5c5241"
         self.build_ui()
 
     def build_ui(self):


### PR DESCRIPTION
### Description

Please include a summary of the change and which issue is fixed or feature is introduced. Please also include relevant motivation and context.

Fixes #33 

### Summary

Added enhancement to the settings. Previously, the user will paste their spotify URL, but there was no way to being able to know where that link led. Now, there is a display name for the title of the spotify playlist or album. If the user were to paste a link to The Beatles' Revolver Album, it will now display to the user "Revolver" so at a glance they know which link they pasted. 

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation the user needs to know)

### Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
I ran some basic regression tests. I deleted my current config.json and ran bootme. It successfully created the new default config file as expected, and I updated the configurations and everything worked. 

### Additional Context (optional)

